### PR TITLE
Consolidate project-level files into todo-docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,17 @@
-# Todo Docs
+# Todo Project
 
-Cross-cutting architectural decision records for the todo application.
+The canonical home for project-wide documentation, operational files, and cross-cutting architectural decision records for the todo application.
 
 ## Purpose
 
-This project holds ADRs that span both the API and web frontend — decisions about project boundaries, API strategy, and deployment approach.
+This repo is the source of truth for project-level concerns that span both `todo-api` and `todo-web`:
+
+- **`docs/adr/`** — Cross-cutting ADRs covering project boundaries, API strategy, and deployment approach
+- **`docs/plans/`** — Feature and milestone plans
+- **`ideas.md`** — Backlog of ideas and future improvements
+- **`status.md`** — Running project journal and status log
+- **`CONTRIBUTORS.md`** — Local development setup and tooling (uses Overmind to run all services)
+- **`Procfile`** — Overmind process definitions for running the full stack locally
 
 ## Git Workflow
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+# setup
+
+Using [overmind](https://github.com/DarthSim/overmind) to run things locally
+```
+brew install tmux overmind
+```
+
+# running
+```
+overmind start
+```
+
+Each process gets a labeled, color-coded output stream. A few useful Overmind commands while it's running:
+```
+overmind connect api   # attach to a specific process (e.g. to use the Flask debugger interactively)
+overmind restart web   # restart just one process
+overmind stop          # graceful shutdown of all
+```

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+api: cd ../todo-api && uv run flask run
+web: cd ../todo-web && /Users/jeffbenton/.nvm/versions/node/v24.13.1/bin/pnpm dev

--- a/docs/plans/3-consolidate-project-docs.md
+++ b/docs/plans/3-consolidate-project-docs.md
@@ -1,0 +1,57 @@
+# Plan: Rename todo-docs to todo-project and Consolidate Project-Level Files
+
+**Issue:** [#3 — Chore: rename todo-docs to todo-project and consolidate project-level files](https://github.com/JeffBentonSdet/todo-docs/issues/3)
+
+## Goal
+
+Expand the role of `todo-docs` from an ADR-only repository to the canonical home for all project-wide documentation and operational files. Rename it `todo-project` to reflect this broader purpose.
+
+## Steps
+
+### 1. Branch
+Create branch `3-consolidate-project-docs` from `main` in `todo-docs`.
+
+### 2. Move files from local `todo-project/` into `todo-docs/`
+Copy the following files into the `todo-docs` repo root:
+
+| Source (`todo-project/`) | Destination (`todo-docs/`) |
+|---|---|
+| `ideas.md` | `ideas.md` |
+| `status.md` | `status.md` |
+| `CONTRIBUTORS.md` | `CONTRIBUTORS.md` |
+| `Procfile` | `Procfile` |
+
+### 3. Update `todo-docs/CLAUDE.md`
+- Expand the purpose section to describe the repo as the home for project-wide docs, not just ADRs
+- Document what each root-level file is for (`ideas.md`, `status.md`, `CONTRIBUTORS.md`, `Procfile`)
+
+### 4. Open PR and merge to `main`
+PR against `main` in `todo-docs`. Merge before renaming the repo so git history is clean.
+
+### 5. Rename the GitHub repository
+In GitHub Settings, rename `todo-docs` → `todo-project`.
+
+### 6. Rename the local directory
+```
+mv todo-docs todo-project
+```
+
+### 7. Update the local remote URL
+```
+cd todo-project
+git remote set-url origin https://github.com/JeffBentonSdet/todo-project.git
+```
+
+### 8. Update references to `todo-docs` across the workspace
+- Root `todo/CLAUDE.md` — update project structure description
+- `todo-api/CLAUDE.md` (if it references `todo-docs`)
+- `todo-web/CLAUDE.md` (if it references `todo-docs`)
+- `todo-project.code-workspace` — update any paths
+
+### 9. Retire the old local `todo-project/` directory
+Remove files that have been migrated. The remaining files (`CLAUDE.md`, `todo-project.code-workspace`) should either move into the new `todo-project` repo or be evaluated for deletion.
+
+## Out of Scope
+
+- No changes to ADR content
+- No changes to `todo-api` or `todo-web` source code

--- a/ideas.md
+++ b/ideas.md
@@ -1,0 +1,7 @@
+# Ideas
+* add "segment" type tracking to the web
+* add observability - tracing to the front and backend
+* add true e2e test at the api layer
+* add code coverage
+* add basic static analysis
+* add story book testing - deferred

--- a/status.md
+++ b/status.md
@@ -1,0 +1,18 @@
+# 2026-02-23T22:25:08   
+
+I am working my way through the web ui initial set of issues. I need to add testing to the web.
+I need to add e2e test for the api.
+I need to double check that my graphql layer returns a schema as expected.
+
+What should I do for running, test and deploying?
+Maybe deploying to local kind cluster?
+
+It seems I lost a little bit of context and I am not sure how to 
+set that properly. Maybe there is a workspace concept for claude.
+
+I'm running into issues with test data. Needing different states to 
+test things out.
+
+Need to add the playwright test too.
+
+Eventually want to add otel tracing


### PR DESCRIPTION
## Summary

- Moves `ideas.md`, `status.md`, `CONTRIBUTORS.md`, and `Procfile` from the local `todo-project/` directory into this repo
- Updates `CLAUDE.md` to reflect the expanded purpose: canonical home for project-wide docs, not just ADRs
- Adds plan file `docs/plans/3-consolidate-project-docs.md`

## Test plan

- [ ] Verify all four files appear in repo root
- [ ] Verify `CLAUDE.md` purpose section is accurate
- [ ] After merge: rename GitHub repo to `todo-project` and update local remote URL

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)