### PR TITLE
Consolidate project docs and rename todo-docs to todo-project

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr_proposal.md
+++ b/.github/ISSUE_TEMPLATE/adr_proposal.md
@@ -18,7 +18,7 @@ What other options should be considered?
 ## Affected Projects
 - [ ] todo-api
 - [ ] todo-web
-- [ ] todo-docs
+- [ ] todo-project
 
 ## Additional Context
 Any references, links, or prior discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,7 @@ As a [type of user], I want [goal] so that [reason].
 ## Affected Projects
 - [ ] todo-api
 - [ ] todo-web
-- [ ] todo-docs
+- [ ] todo-project
 
 ## Additional Context
 Any other details, mockups, or references.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,17 @@
-# Todo Docs
+# Todo Project
 
-Cross-cutting architectural decision records for the todo application.
+The canonical home for project-wide documentation, operational files, and cross-cutting architectural decision records for the todo application.
 
 ## Purpose
 
-This project holds ADRs that span both the API and web frontend — decisions about project boundaries, API strategy, and deployment approach.
+This repo is the source of truth for project-level concerns that span both `todo-api` and `todo-web`:
+
+- **`docs/adr/`** — Cross-cutting ADRs covering project boundaries, API strategy, and deployment approach
+- **`docs/plans/`** — Feature and milestone plans
+- **`ideas.md`** — Backlog of ideas and future improvements
+- **`status.md`** — Running project journal and status log
+- **`CONTRIBUTORS.md`** — Local development setup and tooling (uses Overmind to run all services)
+- **`Procfile`** — Overmind process definitions for running the full stack locally
 
 ## Git Workflow
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,18 @@
+# setup
+
+Using [overmind](https://github.com/DarthSim/overmind) to run things locally
+```
+brew install tmux overmind
+```
+
+# running
+```
+overmind start
+```
+
+Each process gets a labeled, color-coded output stream. A few useful Overmind commands while it's running:
+```
+overmind connect api   # attach to a specific process (e.g. to use the Flask debugger interactively)
+overmind restart web   # restart just one process
+overmind stop          # graceful shutdown of all
+```

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+api: cd ../todo-api && uv run flask run
+web: cd ../todo-web && /Users/jeffbenton/.nvm/versions/node/v24.13.1/bin/pnpm dev

--- a/docs/adr/001-separate-frontend-backend-repos.md
+++ b/docs/adr/001-separate-frontend-backend-repos.md
@@ -9,7 +9,7 @@ The todo application requires both a web frontend and a backend API. As the proj
 Team autonomy, independent release cadences, and clear ownership boundaries are important considerations for long-term maintainability. Different teams may have different tooling preferences, CI/CD pipelines, and deployment targets.
 
 ## Decision
-The project is split into separate frontend (`todo-web`) and backend (`todo-api`) projects, each representing separate team ownership. A shared `todo-docs` project houses cross-cutting architectural decisions and documentation.
+The project is split into separate frontend (`todo-web`) and backend (`todo-api`) projects, each representing separate team ownership. A shared `todo-project` repository houses cross-cutting architectural decisions and project-wide documentation.
 
 ## Alternatives Considered
 - **Monorepo with shared tooling (e.g., Turborepo, Nx):** Would simplify cross-project changes and dependency management, but introduces coupling between teams and requires agreement on shared tooling. Adds complexity for teams that want to move independently.

--- a/docs/adr/004-github-project-management.md
+++ b/docs/adr/004-github-project-management.md
@@ -4,7 +4,7 @@
 Accepted
 
 ## Context
-The todo application is split across three repositories (todo-docs, todo-api, todo-web) with independent deployment lifecycles. Each merge to main triggers a CI/CD pipeline that builds and releases automatically. We need a project management approach that provides cross-repo visibility, supports a continuous flow of work without fixed sprints, and integrates naturally with the GitHub-based development workflow.
+The todo application is split across three repositories (todo-project, todo-api, todo-web) with independent deployment lifecycles. Each merge to main triggers a CI/CD pipeline that builds and releases automatically. We need a project management approach that provides cross-repo visibility, supports a continuous flow of work without fixed sprints, and integrates naturally with the GitHub-based development workflow.
 
 ## Decision
 We use GitHub's native project management features with a kanban workflow:
@@ -48,7 +48,7 @@ A consistent label scheme is applied across all three repositories:
 Each repository has standardized issue templates:
 - **Bug report** — Steps to reproduce, expected vs actual behavior, environment
 - **Feature request** — User story, acceptance criteria, affected projects
-- **ADR proposal** (todo-docs only) — Problem statement, proposed decision, alternatives
+- **ADR proposal** (todo-project only) — Problem statement, proposed decision, alternatives
 
 ### What We Don't Use
 - **Milestones** — Not needed; no sprints or release groupings since every merge to main deploys automatically via CI/CD

--- a/docs/plans/3-consolidate-project-docs.md
+++ b/docs/plans/3-consolidate-project-docs.md
@@ -1,0 +1,57 @@
+# Plan: Rename todo-docs to todo-project and Consolidate Project-Level Files
+
+**Issue:** [#3 — Chore: rename todo-docs to todo-project and consolidate project-level files](https://github.com/JeffBentonSdet/todo-docs/issues/3)
+
+## Goal
+
+Expand the role of `todo-docs` from an ADR-only repository to the canonical home for all project-wide documentation and operational files. Rename it `todo-project` to reflect this broader purpose.
+
+## Steps
+
+### 1. Branch
+Create branch `3-consolidate-project-docs` from `main` in `todo-docs`.
+
+### 2. Move files from local `todo-project/` into `todo-docs/`
+Copy the following files into the `todo-docs` repo root:
+
+| Source (`todo-project/`) | Destination (`todo-docs/`) |
+|---|---|
+| `ideas.md` | `ideas.md` |
+| `status.md` | `status.md` |
+| `CONTRIBUTORS.md` | `CONTRIBUTORS.md` |
+| `Procfile` | `Procfile` |
+
+### 3. Update `todo-docs/CLAUDE.md`
+- Expand the purpose section to describe the repo as the home for project-wide docs, not just ADRs
+- Document what each root-level file is for (`ideas.md`, `status.md`, `CONTRIBUTORS.md`, `Procfile`)
+
+### 4. Open PR and merge to `main`
+PR against `main` in `todo-docs`. Merge before renaming the repo so git history is clean.
+
+### 5. Rename the GitHub repository
+In GitHub Settings, rename `todo-docs` → `todo-project`.
+
+### 6. Rename the local directory
+```
+mv todo-docs todo-project
+```
+
+### 7. Update the local remote URL
+```
+cd todo-project
+git remote set-url origin https://github.com/JeffBentonSdet/todo-project.git
+```
+
+### 8. Update references to `todo-docs` across the workspace
+- Root `todo/CLAUDE.md` — update project structure description
+- `todo-api/CLAUDE.md` (if it references `todo-docs`)
+- `todo-web/CLAUDE.md` (if it references `todo-docs`)
+- `todo-project.code-workspace` — update any paths
+
+### 9. Retire the old local `todo-project/` directory
+Remove files that have been migrated. The remaining files (`CLAUDE.md`, `todo-project.code-workspace`) should either move into the new `todo-project` repo or be evaluated for deletion.
+
+## Out of Scope
+
+- No changes to ADR content
+- No changes to `todo-api` or `todo-web` source code

--- a/docs/plans/issue-9-view-todos-prompt.md
+++ b/docs/plans/issue-9-view-todos-prompt.md
@@ -1,0 +1,91 @@
+# Issue 9: View Todos — Implementation Prompt
+
+## Context
+
+You are working on the `todo-web` project, a Next.js 15 / TypeScript frontend for a todo application. The project uses Vertical Slice Architecture, TanStack Query for data fetching, and urql for GraphQL.
+
+**Working directory:** `todo-web/`
+
+Before writing any code, follow the git workflow:
+1. Create a GitHub Issue for this work (title: "View todos page — wire up data fetching and render todo list")
+2. Branch from `main` using the convention `<issue-number>-view-todos` (e.g., `9-view-todos`)
+3. Merge via Pull Request — do not commit directly to `main`
+
+---
+
+## What's Already Built
+
+All the pieces exist — this task is purely integration work.
+
+### Hooks (ready to use)
+- `src/features/todos/queries.ts` — `useTodos(filter?)` hook that fetches all todos via REST
+
+### Components (ready to use)
+- `src/components/todos/todo-list.tsx` — renders a list of `TodoItem` components; accepts a `todos` array and callbacks
+- `src/components/todos/todo-item.tsx` — renders a single todo with toggle and delete buttons; accepts `onStatusChange` and `onDelete` callbacks
+- `src/components/todos/todo-filters.tsx` — status and search filter UI; accepts filter state and a change callback
+- `src/components/layout/page-header.tsx` — page title header component
+
+### Page files (exist but incomplete)
+- `src/app/(app)/todos/page.tsx` — currently has a placeholder, needs real implementation
+- `src/app/(app)/todos/loading.tsx` — skeleton UI, already complete
+- `src/app/(app)/todos/error.tsx` — error boundary, already complete
+
+### Types
+- `src/features/todos/types.ts` — `Todo`, `TodoStatus`, `TodoFilter` interfaces
+
+---
+
+## What Needs to Be Done
+
+Wire up `src/app/(app)/todos/page.tsx` so it:
+
+1. **Fetches todos** using the `useTodos()` hook from `src/features/todos/queries.ts`
+2. **Renders the todo list** using the `TodoList` component
+3. **Shows the create form** — mount `TodoForm` in this page (wiring to mutations is covered in Issue 10; for now, `onSubmit` can be a no-op or left as a prop)
+4. **Shows filters** — mount `TodoFilters` and connect local filter state to `useTodos(filter)`
+5. **Handles loading and empty states** — the `loading.tsx` skeleton fires automatically via Suspense; ensure the page renders correctly when the list is empty
+
+The page must be a **Client Component** (`"use client"`) because it uses hooks.
+
+### Acceptance criteria
+- Navigating to `/todos` shows the list of todos fetched from the API
+- A loading skeleton appears while the request is in flight
+- An empty state is shown when there are no todos
+- The filter UI updates which todos are shown
+- No TypeScript errors
+- No console errors
+
+---
+
+## Key Files to Read First
+
+Before writing code, read these files to understand the existing contracts:
+
+- `src/app/(app)/todos/page.tsx` — see what's there now
+- `src/features/todos/queries.ts` — understand `useTodos` signature and return shape
+- `src/features/todos/types.ts` — `Todo` and `TodoFilter` types
+- `src/components/todos/todo-list.tsx` — props interface
+- `src/components/todos/todo-item.tsx` — props interface
+- `src/components/todos/todo-filters.tsx` — props interface
+- `src/components/todos/todo-form.tsx` — props interface (for mounting, not wiring yet)
+
+---
+
+## Architecture Notes
+
+- **Vertical Slice:** feature logic lives in `src/features/todos/`, UI components in `src/components/todos/`
+- **Client vs Server Components:** pages that use hooks must be `"use client"`; the `loading.tsx` and `error.tsx` files handle Suspense/error boundaries automatically in Next.js App Router
+- **TanStack Query:** `useTodos()` returns `{ data, isLoading, isError, error }` — use these for conditional rendering
+- **API base URL:** configured via `NEXT_PUBLIC_API_BASE_URL` in `.env.example` — ensure `.env.local` is set pointing at the running `todo-api`
+
+---
+
+## Out of Scope for This Issue
+
+Do not implement these — they are separate issues:
+- Creating todos (Issue 10)
+- Toggling todo completed (Issue 11)
+- Deleting todos (Issue 12)
+
+Callbacks like `onStatusChange` and `onDelete` on `TodoItem` can be passed as no-ops (`() => {}`) for now.

--- a/ideas.md
+++ b/ideas.md
@@ -1,0 +1,7 @@
+# Ideas
+* add "segment" type tracking to the web
+* add observability - tracing to the front and backend
+* add true e2e test at the api layer
+* add code coverage
+* add basic static analysis
+* add story book testing - deferred

--- a/status.md
+++ b/status.md
@@ -1,0 +1,18 @@
+# 2026-02-23T22:25:08   
+
+I am working my way through the web ui initial set of issues. I need to add testing to the web.
+I need to add e2e test for the api.
+I need to double check that my graphql layer returns a schema as expected.
+
+What should I do for running, test and deploying?
+Maybe deploying to local kind cluster?
+
+It seems I lost a little bit of context and I am not sure how to 
+set that properly. Maybe there is a workspace concept for claude.
+
+I'm running into issues with test data. Needing different states to 
+test things out.
+
+Need to add the playwright test too.
+
+Eventually want to add otel tracing

--- a/todo-project.code-workspace
+++ b/todo-project.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../todo-api"
+		},
+		{
+			"path": "../todo-web"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
## Summary
- Expands repo purpose from ADR-only to canonical project-wide documentation home
- Adds `ideas.md`, `status.md`, `CONTRIBUTORS.md`, `Procfile`, and `CLAUDE.md` updates
- Renames all `todo-docs` references to `todo-project` across ADRs, issue templates, and workspace files
- Adds VS Code workspace file and Issue #9 view-todos implementation prompt

## Test plan
- [ ] All `todo-docs` references replaced with `todo-project`
- [ ] Issue templates in todo-project, todo-api, and todo-web updated
- [ ] ADR-001 and ADR-004 reflect the new repo name
- [ ] Remote URL points to `todo-project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)